### PR TITLE
增加 SOCKS5 代理支持

### DIFF
--- a/NatTypeTester/MainWindow.xaml
+++ b/NatTypeTester/MainWindow.xaml
@@ -41,6 +41,51 @@
 					</ComboBox.ItemTemplate>
 				</ComboBox>
 			</Grid>
+			<Grid>
+				<Grid.ColumnDefinitions>
+					<ColumnDefinition Width="Auto"/>
+					<ColumnDefinition Width="2*" />
+				</Grid.ColumnDefinitions>
+				<Grid Margin="0,5,5,5" Grid.Column="0">
+					<Grid.RowDefinitions>
+						<RowDefinition Height="Auto"/>
+						<RowDefinition Height="Auto"/>
+						<RowDefinition/>
+					</Grid.RowDefinitions>
+					<Grid.ColumnDefinitions>
+						<ColumnDefinition/>
+					</Grid.ColumnDefinitions>
+					<RadioButton Grid.Row="0" Grid.Column="0" Content="No Proxy" GroupName="ProxyTypeGroup" Name="ProxyTypeNoneRadio"
+								 HorizontalAlignment="Left" Margin="5" VerticalAlignment="Top" IsChecked="True"/>
+					<RadioButton Grid.Row="1" Grid.Column="0" Content="Socks5 Proxy" GroupName="ProxyTypeGroup" Name="ProxyTypeSocks5Radio"
+								 HorizontalAlignment="Left" Margin="5" VerticalAlignment="Top"/>
+				</Grid>
+				<Grid x:Name="ProxyConfigGrid" Margin="2.6,5,5.4,4.8" Grid.Column="1" IsEnabled="False">
+					<Grid.RowDefinitions>
+						<RowDefinition/>
+						<RowDefinition/>
+						<RowDefinition/>
+					</Grid.RowDefinitions>
+					<Grid.ColumnDefinitions>
+						<ColumnDefinition Width="Auto" MinWidth="115.2"/>
+						<ColumnDefinition/>
+					</Grid.ColumnDefinitions>
+					<TextBox x:Name="ProxyServerTextBox" Grid.Row="0" Grid.Column="1"
+						         Height="23" Margin="5" IsReadOnly="False"
+						         VerticalContentAlignment="Center" VerticalAlignment="Center" />
+					<TextBox x:Name="ProxyUsernameTextBox" Grid.Row="1" Grid.Column="1"
+						         Height="23" Margin="5" IsReadOnly="False"
+						         VerticalContentAlignment="Center" VerticalAlignment="Center" />
+					<TextBox x:Name="ProxyPasswordTextBox" Grid.Row="2" Grid.Column="1"
+						         Height="24" Margin="5" IsReadOnly="False"
+						         VerticalContentAlignment="Center" VerticalAlignment="Center" />
+					<TextBlock Grid.Row="0" Grid.Column="0" Margin="5,9,1.2,8.8" VerticalAlignment="Center"  Text="Proxy Address" Height="15" />
+					<TextBlock Grid.Row="1" Grid.Column="0" Margin="5,9.2,1.2,8.6" VerticalAlignment="Center"  Text="Proxy Username" Height="15" />
+					<TextBlock Grid.Row="2" Grid.Column="0" Margin="5,8.4,1.2,8.4" VerticalAlignment="Center"  Text="Proxy Password" Height="16" />
+				</Grid>
+			</Grid>
+
+
 			<TabControl>
 				<TabItem Header="RFC 5780" x:Name="RFC5780Tab">
 					<Grid>

--- a/NatTypeTester/MainWindow.xaml.cs
+++ b/NatTypeTester/MainWindow.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Reactive;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
@@ -31,6 +32,28 @@ namespace NatTypeTester
                 ).DisposeWith(disposableRegistration);
 
                 #endregion
+
+
+                this.OneWayBind(ViewModel,
+                        vm => vm.CanConfigProxy,
+                        v => v.ProxyConfigGrid.IsEnabled
+                ).DisposeWith(disposableRegistration);
+
+                this.Bind(ViewModel,
+                        vm => vm.ProxyServer,
+                        v => v.ProxyServerTextBox.Text
+                ).DisposeWith(disposableRegistration);
+
+                this.Bind(ViewModel,
+                        vm => vm.ProxyUser,
+                        v => v.ProxyUsernameTextBox.Text
+                ).DisposeWith(disposableRegistration);
+
+                this.Bind(ViewModel,
+                        vm => vm.ProxyPassword,
+                        v => v.ProxyPasswordTextBox.Text
+                ).DisposeWith(disposableRegistration);
+
 
                 #region RFC3489
 

--- a/NatTypeTester/ViewModels/MainWindowViewModel.cs
+++ b/NatTypeTester/ViewModels/MainWindowViewModel.cs
@@ -145,7 +145,7 @@ namespace NatTypeTester.ViewModels
 
         private IObservable<Unit> TestClassicNatTypeImpl()
         {
-            return Observable.Start(() =>
+            return Observable.FromAsync(async () =>
             {
                 try
                 {
@@ -158,7 +158,7 @@ namespace NatTypeTester.ViewModels
                                 .Subscribe(t => ClassicNatType = $@"{t}");
                         client.PubChanged.ObserveOn(RxApp.MainThreadScheduler).Subscribe(t => PublicEnd = $@"{t}");
                         client.LocalChanged.ObserveOn(RxApp.MainThreadScheduler).Subscribe(t => LocalEnd = $@"{t}");
-                        client.Query();
+                        await client.Query3489Async();
                     }
                     else
                     {
@@ -169,7 +169,7 @@ namespace NatTypeTester.ViewModels
                 {
                     MessageBox.Show(ex.Message, nameof(NatTypeTester), MessageBoxButton.OK, MessageBoxImage.Error);
                 }
-            });
+            }).SubscribeOn(RxApp.TaskpoolScheduler);
         }
 
         private IObservable<Unit> DiscoveryNatTypeImpl()

--- a/NatTypeTester/ViewModels/MainWindowViewModel.cs
+++ b/NatTypeTester/ViewModels/MainWindowViewModel.cs
@@ -111,6 +111,8 @@ namespace NatTypeTester.ViewModels
 
         #region Proxy
 
+        public bool CanConfigProxy => ProxyType != ProxyType.Plain;
+
         private ProxyType _proxyType = ProxyType.Socks5;
         public ProxyType ProxyType
         {

--- a/NatTypeTester/ViewModels/MainWindowViewModel.cs
+++ b/NatTypeTester/ViewModels/MainWindowViewModel.cs
@@ -195,10 +195,8 @@ namespace NatTypeTester.ViewModels
                             ProxyUser, ProxyPassword
                             );
 
-                        using var client = new StunClient3489(server.Hostname, proxy, server.Port,
-                                NetUtils.ParseEndpoint(LocalEnd));
-
-
+                        using var client = new StunClient3489(server.Hostname, server.Port,
+                                NetUtils.ParseEndpoint(LocalEnd), proxy);
 
                         client.NatTypeChanged.ObserveOn(RxApp.MainThreadScheduler)
                                 .Subscribe(t => ClassicNatType = $@"{t}");
@@ -234,7 +232,7 @@ namespace NatTypeTester.ViewModels
                             ProxyUser, ProxyPassword
                             );
 
-                        using var client = new StunClient5389UDP(server.Hostname, proxy, server.Port, NetUtils.ParseEndpoint(LocalAddress));
+                        using var client = new StunClient5389UDP(server.Hostname, server.Port, NetUtils.ParseEndpoint(LocalAddress), proxy);
 
 
 

--- a/NatTypeTester/ViewModels/MainWindowViewModel.cs
+++ b/NatTypeTester/ViewModels/MainWindowViewModel.cs
@@ -10,6 +10,8 @@ using DynamicData.Binding;
 using NatTypeTester.Model;
 using ReactiveUI;
 using STUN.Client;
+using STUN.Enums;
+using STUN.Proxy;
 using STUN.Utils;
 
 namespace NatTypeTester.ViewModels
@@ -107,6 +109,38 @@ namespace NatTypeTester.ViewModels
 
         #endregion
 
+        #region Proxy
+
+        private ProxyType _proxyType = ProxyType.Socks5;
+        public ProxyType ProxyType
+        {
+            get => _proxyType;
+            set => this.RaiseAndSetIfChanged(ref _proxyType, value);
+        }
+
+        private string _proxyServer = "127.0.0.1:1081";
+        public string ProxyServer
+        {
+            get => _proxyServer;
+            set => this.RaiseAndSetIfChanged(ref _proxyServer, value);
+        }
+
+        private string _proxyUser;
+        public string ProxyUser
+        {
+            get => _proxyUser;
+            set => this.RaiseAndSetIfChanged(ref _proxyUser, value);
+        }
+
+        private string _proxyPassword;
+        public string ProxyPassword
+        {
+            get => _proxyPassword;
+            set => this.RaiseAndSetIfChanged(ref _proxyPassword, value);
+        }
+
+        #endregion
+
         public MainWindowViewModel()
         {
             LoadStunServer();
@@ -152,8 +186,18 @@ namespace NatTypeTester.ViewModels
                     var server = new StunServer();
                     if (server.Parse(StunServer))
                     {
-                        using var client = new StunClient3489(server.Hostname, server.Port,
+                        var proxy = ProxyFactory.CreateProxy(
+                            ProxyType,
+                            NetUtils.ParseEndpoint(LocalEnd),
+                            NetUtils.ParseEndpoint(ProxyServer),
+                            ProxyUser, ProxyPassword
+                            );
+
+                        using var client = new StunClient3489(server.Hostname, proxy, server.Port,
                                 NetUtils.ParseEndpoint(LocalEnd));
+
+
+
                         client.NatTypeChanged.ObserveOn(RxApp.MainThreadScheduler)
                                 .Subscribe(t => ClassicNatType = $@"{t}");
                         client.PubChanged.ObserveOn(RxApp.MainThreadScheduler).Subscribe(t => PublicEnd = $@"{t}");
@@ -181,7 +225,16 @@ namespace NatTypeTester.ViewModels
                     var server = new StunServer();
                     if (server.Parse(StunServer))
                     {
-                        using var client = new StunClient5389UDP(server.Hostname, server.Port, NetUtils.ParseEndpoint(LocalAddress));
+                        var proxy = ProxyFactory.CreateProxy(
+                            ProxyType,
+                            NetUtils.ParseEndpoint(LocalEnd),
+                            NetUtils.ParseEndpoint(ProxyServer),
+                            ProxyUser, ProxyPassword
+                            );
+
+                        using var client = new StunClient5389UDP(server.Hostname, proxy, server.Port, NetUtils.ParseEndpoint(LocalAddress));
+
+
 
                         client.BindingTestResultChanged
                                 .ObserveOn(RxApp.MainThreadScheduler)

--- a/STUN/Client/StunClient3489.cs
+++ b/STUN/Client/StunClient3489.cs
@@ -49,7 +49,7 @@ namespace STUN.Client
 
         protected IUdpProxy Proxy;
 
-        public StunClient3489(string server, IUdpProxy proxy = null, ushort port = 3478, IPEndPoint local = null, IDnsQuery dnsQuery = null)
+        public StunClient3489(string server, ushort port = 3478, IPEndPoint local = null, IUdpProxy proxy = null, IDnsQuery dnsQuery = null)
         {
             Proxy = proxy ?? new NoneUdpProxy(local, null);
 

--- a/STUN/Client/StunClient3489.cs
+++ b/STUN/Client/StunClient3489.cs
@@ -51,7 +51,7 @@ namespace STUN.Client
 
         public StunClient3489(string server, ushort port = 3478, IPEndPoint local = null, IDnsQuery dnsQuery = null)
         {
-            Proxy = new NoneUdpProxy(local, null);
+            Proxy = new Socks5UdpProxy(local, new IPEndPoint(IPAddress.Parse("127.0.0.1"), 1081));
             Func<string, IPAddress> dnsQuery1;
             if (string.IsNullOrEmpty(server))
             {
@@ -90,6 +90,7 @@ namespace STUN.Client
 
             try
             {
+                await Proxy.ConnectAsync();
                 // test I
                 var test1 = new StunMessage5389 { StunMessageType = StunMessageType.BindingRequest, MagicCookie = 0 };
 
@@ -194,6 +195,7 @@ namespace STUN.Client
             }
             finally
             {
+                await Proxy.DisconnectAsync();
                 _natTypeSubj.OnNext(res.NatType);
                 PubSubj.OnNext(res.PublicEndPoint);
             }

--- a/STUN/Client/StunClient3489.cs
+++ b/STUN/Client/StunClient3489.cs
@@ -49,9 +49,10 @@ namespace STUN.Client
 
         protected IUdpProxy Proxy;
 
-        public StunClient3489(string server, ushort port = 3478, IPEndPoint local = null, IDnsQuery dnsQuery = null)
+        public StunClient3489(string server, IUdpProxy proxy = null, ushort port = 3478, IPEndPoint local = null, IDnsQuery dnsQuery = null)
         {
-            Proxy = new Socks5UdpProxy(local, new IPEndPoint(IPAddress.Parse("127.0.0.1"), 1081));
+            Proxy = proxy ?? new NoneUdpProxy(local, null);
+
             Func<string, IPAddress> dnsQuery1;
             if (string.IsNullOrEmpty(server))
             {

--- a/STUN/Client/StunClient5389UDP.cs
+++ b/STUN/Client/StunClient5389UDP.cs
@@ -259,42 +259,6 @@ namespace STUN.Client
             }
         }
 
-        private async Task<(StunMessage5389, IPEndPoint, IPAddress)> TestAsync(StunMessage5389 sendMessage, IPEndPoint remote, IPEndPoint receive)
-        {
-            try
-            {
-                var b1 = sendMessage.Bytes.ToArray();
-                //var t = DateTime.Now;
-
-                // Simple retransmissions
-                //https://tools.ietf.org/html/rfc5389#section-7.2.1
-                //while (t + TimeSpan.FromSeconds(6) > DateTime.Now)
-                {
-                    try
-                    {
-
-                        var (receive1, ipe, local) = await UdpClient.UdpReceiveAsync(b1, remote, receive);
-
-                        var message = new StunMessage5389();
-                        if (message.TryParse(receive1) &&
-                            message.ClassicTransactionId.IsEqual(sendMessage.ClassicTransactionId))
-                        {
-                            return (message, ipe, local);
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        Debug.WriteLine(ex);
-                    }
-                }
-            }
-            catch (Exception ex)
-            {
-                Debug.WriteLine(ex);
-            }
-            return (null, null, null);
-        }
-
         public override void Dispose()
         {
             base.Dispose();

--- a/STUN/Client/StunClient5389UDP.cs
+++ b/STUN/Client/StunClient5389UDP.cs
@@ -1,6 +1,7 @@
 ﻿using STUN.Enums;
 using STUN.Interfaces;
 using STUN.Message;
+using STUN.Proxy;
 using STUN.StunResult;
 using STUN.Utils;
 using System;
@@ -32,8 +33,8 @@ namespace STUN.Client
 
         #endregion
 
-        public StunClient5389UDP(string server, ushort port = 3478, IPEndPoint local = null, IDnsQuery dnsQuery = null)
-        : base(server, port, local, dnsQuery)
+        public StunClient5389UDP(string server, IUdpProxy proxy, ushort port = 3478, IPEndPoint local = null, IDnsQuery dnsQuery = null)
+        : base(server, proxy, port, local, dnsQuery)
         {
             Timeout = TimeSpan.FromSeconds(3);
         }

--- a/STUN/Enums/ProxyType.cs
+++ b/STUN/Enums/ProxyType.cs
@@ -1,0 +1,8 @@
+﻿namespace STUN.Enums
+{
+    public enum ProxyType
+    {
+        Plain,
+        Socks5,
+    }
+}

--- a/STUN/Enums/TransportType.cs
+++ b/STUN/Enums/TransportType.cs
@@ -1,0 +1,12 @@
+﻿namespace STUN.Enums
+{
+    // Only UDP is supported
+
+    public enum TransportType
+    {
+        Udp,
+        Tcp,
+        Tls,
+        Dtls,
+    }
+}

--- a/STUN/Proxy/IUdpProxy.cs
+++ b/STUN/Proxy/IUdpProxy.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Net;
+using System.Threading.Tasks;
+
+namespace STUN.Proxy
+{
+    public interface IUdpProxy
+    {
+        TimeSpan Timeout { get; set; }
+        IPEndPoint LocalEndPoint { get; }
+        Task ConnectAsync(IPEndPoint local, IPEndPoint remote);
+        Task<(byte[], IPEndPoint, IPAddress)> RecieveAsync(byte[] bytes, IPEndPoint remote, EndPoint receive);
+        Task DisconnectAsync();
+    }
+}

--- a/STUN/Proxy/IUdpProxy.cs
+++ b/STUN/Proxy/IUdpProxy.cs
@@ -4,11 +4,11 @@ using System.Threading.Tasks;
 
 namespace STUN.Proxy
 {
-    public interface IUdpProxy
+    public interface IUdpProxy : IDisposable
     {
         TimeSpan Timeout { get; set; }
         IPEndPoint LocalEndPoint { get; }
-        Task ConnectAsync(IPEndPoint local, IPEndPoint remote);
+        Task ConnectAsync();
         Task<(byte[], IPEndPoint, IPAddress)> RecieveAsync(byte[] bytes, IPEndPoint remote, EndPoint receive);
         Task DisconnectAsync();
     }

--- a/STUN/Proxy/NoneUdpProxy.cs
+++ b/STUN/Proxy/NoneUdpProxy.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace STUN.Proxy
+{
+    class NoneUdpProxy : IUdpProxy
+    {
+
+        public TimeSpan Timeout
+        {
+            get => TimeSpan.FromMilliseconds(UdpClient.Client.ReceiveTimeout);
+            set => UdpClient.Client.ReceiveTimeout = Convert.ToInt32(value.TotalMilliseconds);
+        }
+
+        public IPEndPoint LocalEndPoint { get => (IPEndPoint)UdpClient.Client.LocalEndPoint; }
+
+        protected UdpClient UdpClient;
+
+        public Task ConnectAsync(IPEndPoint local, IPEndPoint remote)
+        {
+            UdpClient = local == null ? new UdpClient() : new UdpClient(local);
+            return Task.CompletedTask;
+        }
+
+        public Task DisconnectAsync()
+        {
+            UdpClient.Close();
+            return Task.CompletedTask;
+        }
+
+        public async Task<(byte[], IPEndPoint, IPAddress)> RecieveAsync(byte[] bytes, IPEndPoint remote, EndPoint receive)
+        {
+            var localEndPoint = (IPEndPoint)UdpClient.Client.LocalEndPoint;
+
+            Debug.WriteLine($@"{localEndPoint} => {remote} {bytes.Length} 字节");
+
+            await UdpClient.SendAsync(bytes, bytes.Length, remote);
+
+            var res = new byte[ushort.MaxValue];
+            var flag = SocketFlags.None;
+
+            var length = UdpClient.Client.ReceiveMessageFrom(res, 0, res.Length, ref flag, ref receive, out var ipPacketInformation);
+
+            var local = ipPacketInformation.Address;
+
+            Debug.WriteLine($@"{(IPEndPoint)receive} => {local} {length} 字节");
+
+            return (res.Take(length).ToArray(),
+                    (IPEndPoint)receive
+                    , local);
+        }
+    }
+}

--- a/STUN/Proxy/NoneUdpProxy.cs
+++ b/STUN/Proxy/NoneUdpProxy.cs
@@ -22,9 +22,13 @@ namespace STUN.Proxy
 
         protected UdpClient UdpClient;
 
-        public Task ConnectAsync(IPEndPoint local, IPEndPoint remote)
+        public NoneUdpProxy(IPEndPoint local, IPEndPoint proxy)
         {
             UdpClient = local == null ? new UdpClient() : new UdpClient(local);
+        }
+
+        public Task ConnectAsync()
+        {
             return Task.CompletedTask;
         }
 
@@ -54,6 +58,11 @@ namespace STUN.Proxy
             return (res.Take(length).ToArray(),
                     (IPEndPoint)receive
                     , local);
+        }
+
+        public void Dispose()
+        {
+            UdpClient?.Dispose();
         }
     }
 }

--- a/STUN/Proxy/ProxyFactory.cs
+++ b/STUN/Proxy/ProxyFactory.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Text;
+using STUN.Enums;
+
+namespace STUN.Proxy
+{
+    public static class ProxyFactory
+    {
+        public static IUdpProxy CreateProxy(ProxyType type, IPEndPoint local, IPEndPoint proxy, string user, string password)
+        {
+            switch (type)
+            {
+                case ProxyType.Plain:
+                    return new NoneUdpProxy(local, null);
+                case ProxyType.Socks5:
+                    return new Socks5UdpProxy(local, proxy);
+                default:
+                    throw new NotSupportedException(type.ToString());
+            }
+        }
+    }
+}

--- a/STUN/Proxy/Socks5UdpProxy.cs
+++ b/STUN/Proxy/Socks5UdpProxy.cs
@@ -1,0 +1,219 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Net;
+using System.Net.NetworkInformation;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading.Tasks;
+using STUN.Utils;
+
+namespace STUN.Proxy
+{
+    class Socks5UdpProxy : IUdpProxy
+    {
+        TcpClient assoc = new TcpClient();
+        IPEndPoint socksTcpEndPoint;
+
+        IPEndPoint assocEndPoint;
+
+        public TimeSpan Timeout
+        {
+            get => TimeSpan.FromMilliseconds(UdpClient.Client.ReceiveTimeout);
+            set => UdpClient.Client.ReceiveTimeout = Convert.ToInt32(value.TotalMilliseconds);
+        }
+
+        public IPEndPoint LocalEndPoint => throw new NotImplementedException();
+
+        UdpClient UdpClient;
+
+        string user;
+        string passwd;
+        public Socks5UdpProxy(IPEndPoint proxy)
+        {
+            socksTcpEndPoint = proxy;
+        }
+
+        public async Task ConnectAsync(IPEndPoint local, IPEndPoint remote)
+        {
+            byte[] buf = new byte[1024];
+
+            UdpClient = local == null ? new UdpClient() : new UdpClient(local);
+            await assoc.ConnectAsync(socksTcpEndPoint.Address, socksTcpEndPoint.Port);
+            try
+            {
+                var s = assoc.GetStream();
+                bool requestPasswordAuth = user != null;
+
+                #region Handshake
+                // we have no gssapi support
+                if (requestPasswordAuth)
+                {
+                    // 5 authlen auth[](0=none, 2=userpasswd)
+                    s.Write(new byte[] { 5, 2, 0, 2 }, 0, 4);
+                }
+                else
+                {
+                    s.Write(new byte[] { 5, 1, 0 }, 0, 3);
+                }
+                // 5 auth(ff=deny)
+                if (s.Read(buf, 0, 2) != 2) throw new ProtocolViolationException();
+                if (buf[0] != 5) throw new ProtocolViolationException();
+                #endregion
+
+                #region Auth
+                var auth = buf[1];
+                switch (auth)
+                {
+                    case 0:
+                        break;
+                    case 2:
+                        byte[] ubyte = Encoding.UTF8.GetBytes(user);
+                        byte[] pbyte = Encoding.UTF8.GetBytes(passwd);
+                        buf[0] = 1;
+                        buf[1] = (byte)ubyte.Length;
+                        Array.Copy(ubyte, 0, buf, 2, ubyte.Length);
+                        buf[ubyte.Length + 3] = (byte)pbyte.Length;
+                        Array.Copy(pbyte, 0, buf, ubyte.Length + 4, pbyte.Length);
+                        // 1 userlen user passlen pass
+                        s.Write(buf, 0, ubyte.Length + pbyte.Length + 4);
+                        // 1 state(0=ok)
+                        if (s.Read(buf, 0, 2) != 2) throw new ProtocolViolationException();
+                        if (buf[0] != 1) throw new ProtocolViolationException();
+                        if (buf[1] != 0) throw new UnauthorizedAccessException();
+                        break;
+                    case 0xff:
+                        throw new UnauthorizedAccessException();
+                    default:
+                        throw new ProtocolViolationException();
+                }
+                #endregion
+
+                #region UDP Assoc Send
+                buf[0] = 5;
+                buf[1] = 3;
+                buf[2] = 0;
+                int addrLen;
+                int port;
+                if (remote is IPEndPoint ir)
+                {
+                    byte[] abyte = ir.Address.GetAddressBytes();
+                    addrLen = abyte.Length;
+                    buf[3] = (byte)(abyte.Length == 4 ? 1 : 4);
+                    Array.Copy(abyte, 0, buf, 4, addrLen);
+                    port = ir.Port;
+                }
+                else
+                {
+                    throw new NotImplementedException();
+                }
+                buf[addrLen + 4] = (byte)(port / 256);
+                buf[addrLen + 5] = (byte)(port % 256);
+
+                // 5 cmd(3=udpassoc) 0 atyp(1=v4 3=dns 4=v5) addr port
+                s.Write(buf, 0, addrLen + 4);
+                #endregion
+
+                #region UDP Assoc Response
+                if (s.Read(buf, 0, 4) != 4) throw new ProtocolViolationException();
+                if (buf[0] != 5 || buf[2] != 0) throw new ProtocolViolationException();
+                if (buf[1] != 0) throw new UnauthorizedAccessException();
+
+                switch (buf[3])
+                {
+                    case 1:
+                        addrLen = 4;
+                        break;
+                    case 4:
+                        addrLen = 16;
+                        break;
+                    default:
+                        throw new NotSupportedException();
+                }
+
+                byte[] addr = new byte[addrLen];
+                if (s.Read(buf, 0, addrLen) != addrLen) throw new ProtocolViolationException();
+                IPAddress assocIP = new IPAddress(addr);
+                if (s.Read(buf, 0, 2) != 2) throw new ProtocolViolationException();
+                int assocPort = buf[0] * 256 + buf[1];
+                #endregion
+
+                assocEndPoint = new IPEndPoint(assocIP, assocPort);
+            }
+            catch (Exception e)
+            {
+                Debug.WriteLine(e);
+                assoc.Close();
+            }
+        }
+
+        public async Task<(byte[], IPEndPoint, IPAddress)> RecieveAsync(byte[] bytes, IPEndPoint remote, EndPoint receive)
+        {
+            TcpState state = assoc.GetState();
+            if (state != TcpState.Established) throw new Exception();
+
+            byte[] remoteBytes = GetEndPointByte(remote);
+            byte[] proxyBytes = new byte[bytes.Length + remoteBytes.Length + 3];
+            Array.Copy(remoteBytes, 0, proxyBytes, 3, proxyBytes.Length);
+            Array.Copy(bytes, 0, proxyBytes, remoteBytes.Length + 3, bytes.Length);
+
+            await UdpClient.SendAsync(proxyBytes, proxyBytes.Length, assocEndPoint);
+            var res = new byte[ushort.MaxValue];
+            var flag = SocketFlags.None;
+
+            var length = UdpClient.Client.ReceiveMessageFrom(res, 0, res.Length, ref flag, ref receive, out var ipPacketInformation);
+
+            if (res[0] != 0 || res[1] != 0 || res[2] != 0)
+            {
+                throw new Exception();
+            }
+
+            int addrLen;
+            switch (res[3])
+            {
+                case 1:
+                    addrLen = 4;
+                    break;
+                case 4:
+                    addrLen = 16;
+                    break;
+                default:
+                    throw new Exception();
+            }
+
+            byte[] ipbyte = new byte[addrLen];
+            Array.Copy(res, 4, ipbyte, 0, addrLen);
+
+            IPAddress ip = new IPAddress(ipbyte);
+            int port = res[addrLen + 4] * 256 + res[addrLen + 5];
+            byte[] ret = new byte[length - addrLen - 6];
+            Array.Copy(res, addrLen + 6, ret, 0, length - addrLen - 6);
+            return (
+                ret,
+                new IPEndPoint(ip, port),
+                ipPacketInformation.Address);
+        }
+
+        public Task DisconnectAsync()
+        {
+            try
+            {
+                assoc.Close();
+            }
+            catch { }
+            return Task.CompletedTask;
+        }
+
+        byte[] GetEndPointByte(IPEndPoint ep)
+        {
+            byte[] ipbyte = ep.Address.GetAddressBytes();
+            byte[] ret = new byte[ipbyte.Length + 3];
+            ret[0] = (byte)(ipbyte.Length == 1 ? 4 : 16);
+            Array.Copy(ipbyte, 0, ret, 1, ipbyte.Length);
+            ret[ipbyte.Length + 1] = (byte)(ep.Port % 256);
+            ret[ipbyte.Length + 2] = (byte)(ep.Port / 256);
+            return ret;
+        }
+    }
+}

--- a/STUN/Utils/NetUtils.cs
+++ b/STUN/Utils/NetUtils.cs
@@ -46,7 +46,7 @@ namespace STUN.Utils
         public static async Task<StunResult5389> NatBehaviorDiscovery(string server, ushort port, IPEndPoint local)
         {
             // proxy is not supported yet
-            using var client = new StunClient5389UDP(server, null, port, local);
+            using var client = new StunClient5389UDP(server, port, local);
             return await client.QueryAsync();
         }
 

--- a/STUN/Utils/NetUtils.cs
+++ b/STUN/Utils/NetUtils.cs
@@ -45,7 +45,8 @@ namespace STUN.Utils
 
         public static async Task<StunResult5389> NatBehaviorDiscovery(string server, ushort port, IPEndPoint local)
         {
-            using var client = new StunClient5389UDP(server, port, local);
+            // proxy is not supported yet
+            using var client = new StunClient5389UDP(server, null, port, local);
             return await client.QueryAsync();
         }
 


### PR DESCRIPTION
在 STUN 客户端中增加了 SOCKS5 代理支持，并相应调整了若干逻辑

API 变更：
- 添加了 `IUdpProxy` ，由 `Socks5UdpProxy` 和 `NoneUdpProxy` 实现此接口
- STUN 客户端现在可以在构造函数中设定使用的代理
- 用于 RFC3489 NAT 类型测试的同步函数 `Query` 现由异步的 `Query3489Async` 代替
- NAT 类型测试函数需在测试前后自行调用 `IUdpProxy.ConnectAsync` 和 `IUdpProxy.DisconnectAsync` 以连接和断开代理

已知问题：
- CLI 和单元测试未使用代理
- 图形界面相应功能不完整（会无视选择，始终使用代理）
