### PR TITLE
代理输入框支持使用主机名

### DIFF
--- a/NatTypeTester/NatTypeTester.csproj
+++ b/NatTypeTester/NatTypeTester.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net48</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <UseWPF>true</UseWPF>
     <ApplicationIcon>icon.ico</ApplicationIcon>
   </PropertyGroup>


### PR DESCRIPTION
因为开发环境无NF48框架，可执行文件框架临时改为NF472了，可合并后改回去

此次提交为代理输入框增加了对`hostname:port`形式的解析支持，代码格式可能有较大差异，可在你的环境进行格式化