### PR TITLE
Update DotNetDllPathPatcher.ps1

### DIFF
--- a/Build/DotNetDllPathPatcher.ps1
+++ b/Build/DotNetDllPathPatcher.ps1
@@ -32,7 +32,7 @@ function Update-Exe {
     }
 
     $bytes = [File]::ReadAllBytes($exe_path)
-    $index = (Get-Content $exe_path -Raw -Encoding 28591).IndexOf("$dll_name`0")
+    $index = (Get-Content $exe_path -Raw -Encoding Ascii).IndexOf("$dll_name`0")
     if ($index -lt 0) {
         throw [InvalidDataException] 'Could not find old dll path'
     }
@@ -48,7 +48,7 @@ function Update-Exe {
     $fs = [File]::OpenWrite($exe_path)
     try {
         $fs.Write($bytes, 0, $index)
-        $fs.Write($new_bytes)
+        $fs.Write($new_bytes, 0, $($new_bytes.Count))
         $fs.Write($bytes, $end_postion, $end_length)
     }
     finally {


### PR DESCRIPTION
嘿哥们，我不太熟悉.net和powershell。我不太确定是不是我自己的问题。
我尝试用powershell运行你的build.ps1来生成可执行文件，却发现它报错了。
![image](https://user-images.githubusercontent.com/44358528/227769192-1e351aca-7b0c-450b-ad03-3e595be09f3c.png)
![image](https://user-images.githubusercontent.com/44358528/227769276-4fbf840d-98f6-4ed0-81cd-0af3f4f59d86.png)

所以我尝试修复了这两个报错。
这个脚本让我很惊讶，dll的路径竟然可以被这么简单的替换掉。你能讲讲这是什么原理吗？我很好奇。我读了你的代码，你似乎很确定只要路径的长度不超过1024个字节，就不会覆盖掉exe文件后面有用的部分，为什么呢。dotnet可执行文件的这一部分到底是什么结构啊？这是导入表的一部分吗？